### PR TITLE
Fix systemd EFI binary regex

### DIFF
--- a/modules/systemd-secure-boot/systemd-boot-builder.py
+++ b/modules/systemd-secure-boot/systemd-boot-builder.py
@@ -241,7 +241,7 @@ def main() -> None:
         sdboot_status = subprocess.check_output(["@systemd@/bin/bootctl", "--path=@efiSysMountPoint@", "status"], universal_newlines=True)
 
         # See status_binaries() in systemd bootctl.c for code which generates this
-        m = re.search("^\W+File:.*/EFI/(BOOT|systemd)/.*\.efi \(systemd-boot (\d+)\)$",
+        m = re.search("^\W+File:.*/EFI/(BOOT|systemd)/.*\.efi \(systemd-boot (\d+(?:\.\d+)?)\)$",
                       sdboot_status, re.IGNORECASE | re.MULTILINE)
         if m is None:
             print("could not find any previously installed systemd-boot")


### PR DESCRIPTION
Regex over output of `bootctl --path=/boot status` failed for me on a system where the would-be selected line looks like `File: └─/EFI/BOOT/BOOTX64.EFI (systemd-boot 249.7)`